### PR TITLE
Improve accessibility of rendered canvas element

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -18,6 +18,8 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -184,12 +186,23 @@ var Identicon = function (_Component) {
     value: function render() {
       var _this2 = this;
 
-      return _react2.default.createElement('canvas', {
+      var _props = this.props,
+          seed = _props.seed,
+          size = _props.size,
+          scale = _props.scale,
+          color = _props.color,
+          bgColor = _props.bgColor,
+          spotColor = _props.spotColor,
+          extraProps = _objectWithoutProperties(_props, ['seed', 'size', 'scale', 'color', 'bgColor', 'spotColor']);
+
+      return _react2.default.createElement('canvas', _extends({
         ref: function ref(identicon) {
           _this2.identicon = identicon;
         },
-        className: 'identicon'
-      });
+        className: 'identicon',
+        'aria-label': 'Identicon',
+        role: 'img'
+      }, extraProps));
     }
   }]);
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -148,12 +148,14 @@ export default class Identicon extends Component {
   }
 
   render() {
+    const { seed, size, scale, color, bgColor, spotColor, ...extraProps } = this.props
     return (
       <canvas
         ref={(identicon) => { this.identicon = identicon; }}
         className="identicon"
         aria-label="Identicon"
         role="img"
+        {...extraProps}
       />
     );
   }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -152,6 +152,8 @@ export default class Identicon extends Component {
       <canvas
         ref={(identicon) => { this.identicon = identicon; }}
         className="identicon"
+        aria-label="Identicon"
+        role="img"
       />
     );
   }


### PR DESCRIPTION
Adds default `role` and `aria-label` attributes. Allow them to be overridden or extra props to be provided by passing any unrecognized props directly to the canvas.